### PR TITLE
Ajout d'un clavier virtuel pour la transcription

### DIFF
--- a/clavier-virtuel-decameron.json
+++ b/clavier-virtuel-decameron.json
@@ -1,0 +1,52 @@
+{
+    "version": "0.1",
+    "name": "clavier-viruel-decameron",
+    "author": "",
+    "characters": [
+        {
+            "row": 0,
+            "column": 0,
+            "character": "·"
+        },
+        {
+            "row": 0,
+            "column": 1,
+            "character": "¶"
+        },
+        {
+            "row": 0,
+            "column": 2,
+            "character": "̃"
+        },
+        {
+            "row": 0,
+            "column": 3,
+            "character": "ꝑ"
+        },
+        {
+            "row": 0,
+            "column": 4,
+            "character": "ꝰ"
+        },
+        {
+            "row": 0,
+            "column": 5,
+            "character": "ſ"
+        },
+        {
+            "row": 0,
+            "column": 6,
+            "character": "ꝓ"
+        },
+        {
+            "row": 0,
+            "column": 7,
+            "character": "⁊"
+        },
+        {
+            "row": 0,
+            "column": 8,
+            "character": "ͥ"
+        }
+    ]
+}


### PR DESCRIPTION
Pour se faciliter la transcription, voici un clavier virtuel à importer dans l'interface de transcription au début de la saisie ! 
Il contient les principaux caractères spéciaux dont nous avons besoin.